### PR TITLE
Set Vercel outputDirectory to dist for Vite build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
### Motivation
- Align Vercel configuration with the repository's Vite build output so deployments stop failing with "No Output Directory named 'frontend' found".

### Description
- Add a root `vercel.json` that declares the project as a `vite` framework, sets the build command to `npm run build`, and sets `outputDirectory` to `dist`.

### Testing
- Ran `npm run build` which completed successfully and produced the `dist` output directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becaf47f688322b63048b78b235081)